### PR TITLE
fix for angular-cli buildOptimizer

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -632,7 +632,7 @@ function animate (prevRect, target) {
     transition: 'none',
     transform: 'translate(' + (prevRect.left - currentRect.left) + 'px,' + (prevRect.top - currentRect.top) + 'px)'
   });
-  target.offsetWidth; // repaint
+  target.focus(); // repaint
   Object.assign(target.style, {transition: 'all ' + animateDuration + 'ms', transform: 'translate(0,0)'});
   clearTimeout(target.animated);
   target.animated = setTimeout(function () {


### PR DESCRIPTION
During prod build using angular-cli ( angular 9), buildOptimizer removes `target.offsetWidth` as useless line of code. Hacks like: 
`
_repaint(target);

_repaint: function(target) {
   return target.offsetWidth;
}
 `
Don't work as well.
